### PR TITLE
fixed multiple screens detection [Windows]

### DIFF
--- a/lib/win32/index.js
+++ b/lib/win32/index.js
@@ -5,12 +5,18 @@ const fs = require('fs')
 const path = require('path')
 const utils = require('../utils')
 
-const { unlinkP, readAndUnlinkP, defaultAll } = utils
+const {
+  unlinkP,
+  readAndUnlinkP,
+  defaultAll
+} = utils
 
-function windowsSnapshot (options = {}) {
+function windowsSnapshot(options = {}) {
   return new Promise((resolve, reject) => {
     const displayName = options.screen
-    const tmpPath = temp.path({ suffix: '.jpg' })
+    const tmpPath = temp.path({
+      suffix: '.jpg'
+    })
     const imgPath = path.resolve(options.filename || tmpPath)
 
     const displayChoice = displayName ? ` /d "${displayName}"` : ''
@@ -38,21 +44,33 @@ const EXAMPLE_DISPLAYS_OUTPUT = '\r\nC:\Users\devetry\screenshot-desktop\lib\win
 function parseDisplaysOutput(output) {
   const
     displaysStartPattern = /2>nul  \|\| /,
-    { 0: match, index } = displaysStartPattern.exec(output)
+    {
+      0: match,
+      index
+    } = displaysStartPattern.exec(output)
   return output.slice(index + match.length)
     .split('\n')
     .map(s => s.replace(/[\n\r]/g, ''))
-    .map(s => s.match(/(.*?);(\d+);(\d+);(\d+);(\d+)/))
+    .map(s => s.match(/(.*?);(.?\d+);(.?\d+);(.?\d+);(.?\d+)/))
     .filter(s => s)
-    .map(m => ({ id: m[1], name: m[1], top: +m[2], right: +m[3], bottom: +m[4], left: +m[5] }))
-    .map(d => Object.assign(d, { height: d.bottom - d.top, width: d.right - d.left }))
+    .map(m => ({
+      id: m[1],
+      name: m[1],
+      top: +m[2],
+      right: +m[3],
+      bottom: +m[4],
+      left: +m[5]
+    }))
+    .map(d => Object.assign(d, {
+      height: d.bottom - d.top,
+      width: d.right - d.left
+    }))
 }
 
 function listDisplays() {
   return new Promise((resolve, reject) => {
     exec(
-      '"' + path.join(__dirname, 'screenCapture_1.3.1.bat') + '" /list',
-      {
+      '"' + path.join(__dirname, 'screenCapture_1.3.1.bat') + '" /list', {
         cwd: __dirname
       },
       (err, stdout) => {


### PR DESCRIPTION
listDisplay didn't returned all monitors information, because the regex just ignored negative values from .bat result. (such like negative positions etc.)
However, this is only fixed on Windows. I've still issue on MacBook that listDisplay doesn't even return at all. I'll try to fix it later.