### PR TITLE
fix(linux): file type detection

### DIFF
--- a/lib/linux/index.js
+++ b/lib/linux/index.js
@@ -150,7 +150,7 @@ function linuxSnapshot (options = {}) {
     listDisplays().then((screens) => {
       const screen = screens.find(options.screen ? screen => screen.id === options.screen : screen => screen.primary)
 
-      const filename = options.filename ? ('"' + options.filename.replace(/"/g, '\\"') + '"') : '-'
+      const filename = options.filename ? (options.filename.replace(/"/g, '\\"')) : '-'
       const execOptions = options.filename ? {} : {
         encoding: 'buffer',
         maxBuffer: maxBuffer(screens)
@@ -158,7 +158,7 @@ function linuxSnapshot (options = {}) {
       const filetype = guessFiletype(filename)
 
       exec(
-        `import -silent -window root -crop ${screen.crop} -screen ${filetype}:${filename} `,
+        `import -silent -window root -crop ${screen.crop} -screen ${filetype}:"${filename}" `,
         execOptions,
         (err, stdout) => {
           if (err) {


### PR DESCRIPTION
This allows to save as .png on Linux, without breaking file names containing spaces.