### PR TITLE
Fix for OSX: specific screen capture

### DIFF
--- a/lib/darwin/index.js
+++ b/lib/darwin/index.js
@@ -8,10 +8,18 @@ const path = require('path')
 const { unlinkP, readAndUnlinkP } = utils
 
 function darwinSnapshot (options = {}) {
-  return new Promise((resolve, reject) => {
+  const performScreenCapture = displays => new Promise((resolve, reject) => {
+
+    // validate displayId
+    const totalDisplays = displays.length
+    if (totalDisplays === 0) {
+      return reject(new Error(`No displays detected try dropping screen option`))
+    }
+    const maxDisplayId = totalDisplays - 1
     const displayId = options.screen || 0
-    if (!Number.isInteger(displayId) || displayId < 0) {
-      return reject(new Error(`Invalid choice of displayId: ${displayId}`))
+    if (!Number.isInteger(displayId) || displayId < 0 || displayId > maxDisplayId) {
+      const validChoiceMsg = (maxDisplayId===0)? '(valid choice is 0 or drop screen option altogether)':`(valid choice is an integer between 0 and ${maxDisplayId})`;
+      return reject(new Error(`Invalid choice of displayId: ${displayId} ${validChoiceMsg}`))
     }
 
     let format = options.format || 'jpg'
@@ -29,13 +37,13 @@ function darwinSnapshot (options = {}) {
       .fill(null)
       .map(() => temp.path({ suffix }))
 
-    let pathsToDelete = []
+    let pathsToUse = []
     if (options.filename) {
       tmpPaths[displayId] = filename
     }
-    pathsToDelete = tmpPaths.slice(displayId)
+    pathsToUse = tmpPaths.slice(0, displayId + 1)
 
-    exec('screencapture' + ' -x -t ' + format + ' ' + tmpPaths.slice(displayId).join(' '),
+    exec('screencapture' + ' -x -t ' + format + ' ' + pathsToUse.join(' '),
       function (err, stdOut) {
         if (err) {
           return reject(err)
@@ -46,13 +54,17 @@ function darwinSnapshot (options = {}) {
             if (err) {
               return reject(err)
             }
-            Promise.all(pathsToDelete.map(unlinkP))
+            Promise.all(pathsToUse.map(unlinkP))
               .then(() => resolve(img))
               .catch((err) => reject(err))
           })
         }
       })
   })
+
+
+
+  return listDisplays().then((displays) => {return performScreenCapture(displays)});
 }
 
 const EXAMPLE_DISPLAYS_OUTPUT = `

--- a/lib/darwin/index.js
+++ b/lib/darwin/index.js
@@ -9,7 +9,6 @@ const { unlinkP, readAndUnlinkP } = utils
 
 function darwinSnapshot (options = {}) {
   const performScreenCapture = displays => new Promise((resolve, reject) => {
-
     // validate displayId
     const totalDisplays = displays.length
     if (totalDisplays === 0) {
@@ -18,7 +17,7 @@ function darwinSnapshot (options = {}) {
     const maxDisplayId = totalDisplays - 1
     const displayId = options.screen || 0
     if (!Number.isInteger(displayId) || displayId < 0 || displayId > maxDisplayId) {
-      const validChoiceMsg = (maxDisplayId===0)? '(valid choice is 0 or drop screen option altogether)':`(valid choice is an integer between 0 and ${maxDisplayId})`;
+      const validChoiceMsg = (maxDisplayId === 0) ? '(valid choice is 0 or drop screen option altogether)' : `(valid choice is an integer between 0 and ${maxDisplayId})`
       return reject(new Error(`Invalid choice of displayId: ${displayId} ${validChoiceMsg}`))
     }
 
@@ -62,9 +61,7 @@ function darwinSnapshot (options = {}) {
       })
   })
 
-
-
-  return listDisplays().then((displays) => {return performScreenCapture(displays)});
+  return listDisplays().then((displays) => { return performScreenCapture(displays) })
 }
 
 const EXAMPLE_DISPLAYS_OUTPUT = `

--- a/lib/darwin/index.js
+++ b/lib/darwin/index.js
@@ -35,7 +35,7 @@ function darwinSnapshot (options = {}) {
     }
     pathsToDelete = tmpPaths.slice(displayId)
 
-    exec('screencapture' + ' -D ' + (displayId + 1) + ' ' + ' -x -t ' + format + ' ' + tmpPaths.slice(displayId).join(' '),
+    exec('screencapture' + ' -x -t ' + format + ' ' + tmpPaths.slice(displayId).join(' '),
       function (err, stdOut) {
         if (err) {
           return reject(err)

--- a/test.js
+++ b/test.js
@@ -43,8 +43,8 @@ test('screenshot to a file', t => {
 
 test('screenshot specific screen to a file', t => {
   t.plan(1)
-  const tmpName = tmpNameSync({ screen: 0 })
-  return screenshot({ filename: tmpName }).then(() => {
+  const tmpName = tmpNameSync()
+  return screenshot({ filename: tmpName, screen: 0}).then(() => {
     t.truthy(existsSync(tmpName))
     unlinkSync(tmpName)
   })

--- a/test.js
+++ b/test.js
@@ -41,6 +41,15 @@ test('screenshot to a file', t => {
   })
 })
 
+test('screenshot specific screen to a file', t => {
+  t.plan(1)
+  const tmpName = tmpNameSync({ screen: 0 })
+  return screenshot({ filename: tmpName }).then(() => {
+    t.truthy(existsSync(tmpName))
+    unlinkSync(tmpName)
+  })
+})
+
 test('screenshot to a file with a space', t => {
   // https://github.com/bencevans/screenshot-desktop/issues/12
   t.plan(1)

--- a/test.js
+++ b/test.js
@@ -44,7 +44,7 @@ test('screenshot to a file', t => {
 test('screenshot specific screen to a file', t => {
   t.plan(1)
   const tmpName = tmpNameSync()
-  return screenshot({ filename: tmpName, screen: 0}).then(() => {
+  return screenshot({ filename: tmpName, screen: 0 }).then(() => {
     t.truthy(existsSync(tmpName))
     unlinkSync(tmpName)
   })


### PR DESCRIPTION
- Removed option `-D`, this fails over for variety of usecases, no good. 
- Current `screencapture` use for multiple screens/displays is to simply specify multiple filenames, so the fix captures all screens/displays, up to the screen of interest, keeps that image, and removes all tmp files, as before.
- I think there was a bug around use of `tmpPaths.slice`, fixed, please check.
- added validation for a number of screens/displays available, as a chanined promise, used existing `listDisplays()` function
- added basic test to check if specific screen option works in principle.