### PR TITLE
feat(linux): add linux library choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ screenshot({ filename: '/Users/brian/Desktop/demo.png' })
 
 - `filename` Optional. Absolute or relative path to save output.
 - `format` Optional. Valid values `png|jpg`. 
+- `linuxLibrary` Optional. Linux only. Valid values `scrot|imagemagick`. Which library to use. Note that scrot does not support format or screen selection.
 
 ## Licence
 

--- a/lib/linux/index.js
+++ b/lib/linux/index.js
@@ -157,8 +157,19 @@ function linuxSnapshot (options = {}) {
       }
       const filetype = options.format || guessFiletype(filename)
 
+      let commandLine = "";
+      switch (options.linuxLibrary) {
+        case "scrot": // Faster. Does not support crop.
+          commandLine = `scrot "${filename}" -e -z "echo \\"${filename}\\""`;
+          break;
+        case "imagemagick":
+        default:
+          commandLine = `import -silent -window root -crop ${screen.crop} -screen ${filetype}:"${filename}" `;
+          break;
+      }
+
       exec(
-        `import -silent -window root -crop ${screen.crop} -screen ${filetype}:"${filename}" `,
+        commandLine,
         execOptions,
         (err, stdout) => {
           if (err) {

--- a/lib/linux/index.js
+++ b/lib/linux/index.js
@@ -157,15 +157,15 @@ function linuxSnapshot (options = {}) {
       }
       const filetype = options.format || guessFiletype(filename)
 
-      let commandLine = "";
+      let commandLine = ''
       switch (options.linuxLibrary) {
-        case "scrot": // Faster. Does not support crop.
-          commandLine = `scrot "${filename}" -e -z "echo \\"${filename}\\""`;
-          break;
-        case "imagemagick":
+        case 'scrot': // Faster. Does not support crop.
+          commandLine = `scrot "${filename}" -e -z "echo \\"${filename}\\""`
+          break
+        case 'imagemagick':
         default:
-          commandLine = `import -silent -window root -crop ${screen.crop} -screen ${filetype}:"${filename}" `;
-          break;
+          commandLine = `import -silent -window root -crop ${screen.crop} -screen ${filetype}:"${filename}" `
+          break
       }
 
       exec(


### PR DESCRIPTION
Fixes #11 by implementing the ability to choose between the `imagemagick` or `scrot` lib on Linux. (Default option is `imagemagick` so backward compatibility is maintained)

When using `scrot` it is not possible to select which screen to capture or cropping, but it is faster than imagemagick.

Screen selection and cropping could probably be implemented for scrot as well using a library if required.