### PR TITLE
Enable windowsHide when using exec on win32

### DIFF
--- a/lib/win32/index.js
+++ b/lib/win32/index.js
@@ -21,7 +21,8 @@ function windowsSnapshot (options = {}) {
     const displayChoice = displayName ? ` /d "${displayName}"` : ''
 
     exec('"' + path.join(__dirname.replace('app.asar', 'app.asar.unpacked'), 'screenCapture_1.3.2.bat') + '" "' + imgPath + '" ' + displayChoice, {
-      cwd: __dirname.replace('app.asar', 'app.asar.unpacked')
+      cwd: __dirname.replace('app.asar', 'app.asar.unpacked'),
+      windowsHide: true
     }, (err, stdout) => {
       if (err) {
         return reject(err)


### PR DESCRIPTION
When using [pm2](https://pm2.keymetrics.io/docs/usage/quick-start/) there is not an open console window for the node process.

With the `windowsHide` key omitted this resulted in the `exec` command creating a new console window in the screen which ended up in the screenshots. This change enables the [`windowsHide`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) options which prevents showing a new console window if one is not open.