### PR TITLE
feat(win32): Add dpiScale to listDisplays() result on Windows

### DIFF
--- a/lib/win32/index.js
+++ b/lib/win32/index.js
@@ -49,7 +49,7 @@ function parseDisplaysOutput (output) {
   return output.slice(index + match.length)
     .split('\n')
     .map(s => s.replace(/[\n\r]/g, ''))
-    .map(s => s.match(/(.*?);(.?\d+);(.?\d+);(.?\d+);(.?\d+)/))
+    .map(s => s.match(/(.*?);(.?\d+);(.?\d+);(.?\d+);(.?\d+);(.?\d*\.?\d+)/))
     .filter(s => s)
     .map(m => ({
       id: m[1],
@@ -57,7 +57,8 @@ function parseDisplaysOutput (output) {
       top: +m[2],
       right: +m[3],
       bottom: +m[4],
-      left: +m[5]
+      left: +m[5],
+      dpiScale: +m[6]
     }))
     .map(d => Object.assign(d, {
       height: d.bottom - d.top,


### PR DESCRIPTION
Working on web applications, sometimes we'd like to have information of so called "high DPI" displays.
This PR aims to include a new property `dpiScale` to resolve it, referring https://stackoverflow.com/questions/29438430/how-to-get-dpi-scale-for-all-screens.

Since I don't know much about Windows API, please let me know if there is any problem.
