### PR TITLE
win32: Fixed errorlevel expansion

### DIFF
--- a/lib/win32/screenCapture_1.3.2.bat
+++ b/lib/win32/screenCapture_1.3.2.bat
@@ -2,7 +2,7 @@
 /*
 :batch
 @echo off
-setlocal
+setlocal enableDelayedExpansion
 
 :: find csc.exe
 set "csc="
@@ -15,7 +15,7 @@ if not exist "%csc%" (
 
 if not exist "%~n0.exe" (
    call %csc% /nologo /r:"Microsoft.VisualBasic.dll" /win32manifest:"app.manifest" /out:"%~n0.exe" "%~dpsfnx0" || (
-      exit /b %errorlevel%
+      exit /b !errorlevel!
    )
 )
 %~n0.exe %*


### PR DESCRIPTION
Without delayed-expansion the value of %errorlevel% gets expanded before the execution of csc.