### PR TITLE
Added ability to take screenshot of a single window

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Ben Evans and screenshot-desktop contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/linux/index.js
+++ b/lib/linux/index.js
@@ -114,6 +114,20 @@ function parseDisplaysOutput (out) {
     })
 }
 
+/*
+Example command and output:
+xprop -root _NET_CLIENT_LIST_STACKING
+
+_NET_CLIENT_LIST_STACKING(WINDOW): window id # 0x4600001, 0x5600008, 0x360067a, 0x4800007, 0x4e00017, 0x3600003, 0x580000a
+
+*/
+function parseWindowListOutput (out) {
+  return out
+    .split('#')[1]
+    .split(',')
+    .map(item => item.trim())
+}
+
 function listDisplays () {
   return new Promise((resolve, reject) => {
     exec('xrandr', (err, stdout) => {
@@ -121,6 +135,17 @@ function listDisplays () {
         return reject(err)
       }
       return resolve(parseDisplaysOutput(stdout))
+    })
+  })
+}
+
+function listWindows () {
+  return new Promise((resolve, reject) => {
+    exec('xprop -root _NET_CLIENT_LIST_STACKING', (err, stdout) => {
+      if (err) {
+        return reject(err)
+      }
+      return resolve(parseWindowListOutput(stdout))
     })
   })
 }
@@ -159,6 +184,10 @@ function linuxSnapshot (options = {}) {
               maxBuffer: maxBuffer(screens)
             }
       const filetype = options.format || guessFiletype(filename)
+      const windowId = options.windowId ? options.windowId : 'root'
+      // Incorrect crop param can screw with taking a screenshot of a single window, it needs to be omitted to work
+      // "root" window is the entire desktop and not a normal window
+      const cropParam = windowId === 'root' ? `-crop ${screen.crop}` : ''
 
       let commandLine = ''
       switch (options.linuxLibrary) {
@@ -167,7 +196,7 @@ function linuxSnapshot (options = {}) {
           break
         case 'imagemagick':
         default:
-          commandLine = `import -silent -window root -crop ${screen.crop} -screen ${filetype}:"${filename}" `
+          commandLine = `import -silent -window ${windowId} ${cropParam} -screen ${filetype}:"${filename}" `
           break
       }
 
@@ -185,6 +214,7 @@ function linuxSnapshot (options = {}) {
   })
 }
 
+linuxSnapshot.listWindows = listWindows
 linuxSnapshot.listDisplays = listDisplays
 linuxSnapshot.parseDisplaysOutput = parseDisplaysOutput
 linuxSnapshot.EXAMPLE_DISPLAYS_OUTPUT = EXAMPLE_DISPLAYS_OUTPUT


### PR DESCRIPTION
I added the ability to take screenshots of a window using the X-Server window ID. Obviously this only works on linux (so far).

I also added the function `screenshot.listWindows()`, which works similar to `screenshot.listDisplays()`. This function can be used to get a list of all windows' IDs. Windows returned by `screenshot.listWindows()` are ordered by X's "stacking order" (whatever that is supposed to mean... (I didn't research it further)).

Example:

```js
const availableWindows = await screenshot.listWindows()
// availableWindows = ['0x4600001', '0x5600008', '0x360067a', '0x4800007', '0x4e00017', '0x3600003', ...]

const randomWindowId = availableWindows[4] // 4 was randomly chosen by fair dice roll

screenshot({windowId: randomWindowId}).then((img) => {
    // img: Buffer filled with jpg of the top-most window
})

```

I'll try to add the same functionality for windows in the near future. Unfortunately I can't add it for Mac, because I don't own one.

Lastly, I added the actual MIT license text, so the project actually complies with its own license:

> ...
> **The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.**
> ...

Feel free to change the attribution line. For now I set it to "Copyright (c) 2020 Ben Evans and screenshot-desktop contributors".
