### PR TITLE
Parse comma in dpiScale field on Windows

### DIFF
--- a/lib/win32/index.js
+++ b/lib/win32/index.js
@@ -50,7 +50,7 @@ function parseDisplaysOutput (output) {
   return output.slice(index + match.length)
     .split('\n')
     .map(s => s.replace(/[\n\r]/g, ''))
-    .map(s => s.match(/(.*?);(.?\d+);(.?\d+);(.?\d+);(.?\d+);(.?\d*\.?\d+)/))
+    .map(s => s.match(/(.*?);(.?\d+);(.?\d+);(.?\d+);(.?\d+);(.?\d*[\.,]?\d+)/))
     .filter(s => s)
     .map(m => ({
       id: m[1],
@@ -59,7 +59,7 @@ function parseDisplaysOutput (output) {
       right: +m[3],
       bottom: +m[4],
       left: +m[5],
-      dpiScale: +m[6]
+      dpiScale: +m[6].replace(',', '.')
     }))
     .map(d => Object.assign(d, {
       height: d.bottom - d.top,


### PR DESCRIPTION
Default `dpiScale` parsing does not work correctly on Windows 10 Home 2004(19041.867). 

Scaling 150% looks like this in output: 

```js
'\\DISPLAY1;0;1920;1080;0;1,5'
```

which in turn appear as `1` instead of `1.5`

This PR add comma parsing so `dpiScale` field is not limited to integers. If `dpiScale` uses dot, than this PR is effectively noop.