### PR TITLE
Add dirname option and add options to the all method

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ screenshot({ filename: '/Users/brian/Desktop/demo.png' })
 - `filename` Optional. Absolute or relative path to save output.
 - `format` Optional. Valid values `png|jpg`. 
 - `linuxLibrary` Optional. Linux only. Valid values `scrot|imagemagick`. Which library to use. Note that scrot does not support format or screen selection.
+- `dirname` Optional. Windows only. Absolute path to the win32 folder (`C:\your\project\node_modules\screenshot-desktop\lib\win32`). Usefull when used inside a webpack project.
+
+## screenshot.listDisplays() options
+
+- `dirname` Optional. Windows only. Absolute path to the win32 folder (`C:\your\project\node_modules\screenshot-desktop\lib\win32`). Usefull when used inside a webpack project.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ screenshot({ filename: '/Users/brian/Desktop/demo.png' })
 
 - `dirname` Optional. Windows only. Absolute path to the win32 folder (`C:\your\project\node_modules\screenshot-desktop\lib\win32`). Usefull when used inside a webpack project.
 
+## screenshot.all() options
+
+- `dirname` Optional. Windows only. Absolute path to the win32 folder (`C:\your\project\node_modules\screenshot-desktop\lib\win32`). Usefull when used inside a webpack project.
+
 ## Licence
 
 MIT &copy; [Ben Evans](https://bencevans.io)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,12 +35,14 @@ function readAndUnlinkP (path) {
   })
 }
 
-function defaultAll (snapshot) {
+function defaultAll (snapshot, options = {}) {
   return new Promise((resolve, reject) => {
-    snapshot.listDisplays()
+    if (options.filename)
+      delete options.filename
+    snapshot.listDisplays(options)
       .then((displays) => {
         const snapsP = displays
-          .map(({ id }) => snapshot({ screen: id }))
+          .map(({ id }) => snapshot({ ...options, screen: id }))
         Promise.all(snapsP)
           .then(resolve)
           .catch(reject)

--- a/lib/win32/index.js
+++ b/lib/win32/index.js
@@ -17,11 +17,12 @@ function windowsSnapshot (options = {}) {
       suffix: `.${format}`
     })
     const imgPath = path.resolve(options.filename || tmpPath)
+    const dirname = options.dirname || __dirname
 
     const displayChoice = displayName ? ` /d "${displayName}"` : ''
 
-    exec('"' + path.join(__dirname.replace('app.asar', 'app.asar.unpacked'), 'screenCapture_1.3.2.bat') + '" "' + imgPath + '" ' + displayChoice, {
-      cwd: __dirname.replace('app.asar', 'app.asar.unpacked'),
+    exec('"' + path.join(dirname.replace('app.asar', 'app.asar.unpacked'), 'screenCapture_1.3.2.bat') + '" "' + imgPath + '" ' + displayChoice, {
+      cwd: dirname.replace('app.asar', 'app.asar.unpacked'),
       windowsHide: true
     }, (err, stdout) => {
       if (err) {
@@ -67,11 +68,13 @@ function parseDisplaysOutput (output) {
     }))
 }
 
-function listDisplays () {
+function listDisplays (options = {}) {
   return new Promise((resolve, reject) => {
+    const dirname = options.dirname || __dirname
+
     exec(
-      '"' + path.join(__dirname.replace('app.asar', 'app.asar.unpacked'), 'screenCapture_1.3.2.bat') + '" /list', {
-        cwd: __dirname.replace('app.asar', 'app.asar.unpacked')
+      '"' + path.join(dirname.replace('app.asar', 'app.asar.unpacked'), 'screenCapture_1.3.2.bat') + '" /list', {
+        cwd: dirname.replace('app.asar', 'app.asar.unpacked')
       },
       (err, stdout) => {
         if (err) {

--- a/lib/win32/index.js
+++ b/lib/win32/index.js
@@ -89,6 +89,6 @@ windowsSnapshot.listDisplays = listDisplays
 windowsSnapshot.availableDisplays = listDisplays
 windowsSnapshot.parseDisplaysOutput = parseDisplaysOutput
 windowsSnapshot.EXAMPLE_DISPLAYS_OUTPUT = EXAMPLE_DISPLAYS_OUTPUT
-windowsSnapshot.all = () => defaultAll(windowsSnapshot)
+windowsSnapshot.all = (options = {}) => defaultAll(windowsSnapshot, options)
 
 module.exports = windowsSnapshot


### PR DESCRIPTION
This PR adds the dirname option which is usefull when the `__dirname` variable does not point to the right path. This is the case inside a webpack project.
It also adds options for the the `all` method, so it is possible to specify format and dirname options.