### PR TITLE
chore: upgrade node versions to supported releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
node.js supported releases in line with https://github.com/nodejs/Release