### PR TITLE
Add an additional check for an already existing screenCapture folder in temp

### DIFF
--- a/lib/win32/index.js
+++ b/lib/win32/index.js
@@ -17,7 +17,10 @@ function copyToTemp () {
   const includeBat = path.join(__dirname, 'screenCapture_1.3.2.bat').replace('app.asar', 'app.asar.unpacked')
   const includeManifest = path.join(__dirname, 'app.manifest').replace('app.asar', 'app.asar.unpacked')
   if (!fs.existsSync(tmpBat)) {
-    fs.mkdirSync(path.join(os.tmpdir(), 'screenCapture'))
+    const tmpDir = path.join(os.tmpdir(), 'screenCapture')
+    if (!fs.existsSync(tmpDir)) {
+      fs.mkdirSync(tmpDir)
+    }
     const sourceData = {
       bat: fs.readFileSync(includeBat),
       manifest: fs.readFileSync(includeManifest)


### PR DESCRIPTION
An additional check is necessary to see if screenCapture folder already exists, since only a check is made for screenCapture_1.3.2.bat.

Refers to bug #275 