### PR TITLE
Remove Pinkie Promise

### DIFF
--- a/lib/darwin/index.js
+++ b/lib/darwin/index.js
@@ -1,4 +1,3 @@
-const Promise = require('pinkie-promise')
 const exec = require('child_process').exec
 const temp = require('temp')
 const fs = require('fs')

--- a/lib/linux/index.js
+++ b/lib/linux/index.js
@@ -1,4 +1,3 @@
-const Promise = require('pinkie-promise')
 const exec = require('child_process').exec
 const path = require('path')
 const defaultAll = require('../utils').defaultAll

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-const Promise = require('pinkie-promise')
 const fs = require('fs')
 
 function unlinkP (path) {

--- a/lib/win32/index.js
+++ b/lib/win32/index.js
@@ -1,4 +1,3 @@
-const Promise = require('pinkie-promise')
 const exec = require('child_process').exec
 const temp = require('temp')
 const path = require('path')

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "pinkie-promise": "^2.0.1",
         "temp": "^0.9.4"
       },
       "devDependencies": {
@@ -3280,25 +3279,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pkg-conf": {
@@ -6603,19 +6583,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
     },
     "pkg-conf": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Capture a screenshot of your local machine",
   "main": "index.js",
   "dependencies": {
-    "pinkie-promise": "^2.0.1",
     "temp": "^0.9.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Pinkie Promise was added to Polyfill the Promise API on Node.js < 0.12.0. We no longer support these versions as sticking to the current Node.js maintenance schedule.