### PR TITLE
fix: ENOENT error in copyToTemp fn

### DIFF
--- a/lib/win32/index.js
+++ b/lib/win32/index.js
@@ -11,18 +11,35 @@ const {
 } = utils
 
 function copyToTemp () {
-  const tmpBat = path.join(os.tmpdir(), 'screenCapture', 'screenCapture_1.3.2.bat')
-  const tmpManifest = path.join(os.tmpdir(), 'screenCapture', 'app.manifest')
-  const includeBat = path.join(__dirname, 'screenCapture_1.3.2.bat').replace('app.asar', 'app.asar.unpacked')
-  const includeManifest = path.join(__dirname, 'app.manifest').replace('app.asar', 'app.asar.unpacked')
+  const batFileName = 'screenCapture_1.3.2.bat'
+  const manifestFileName = 'app.manifest'
+  const tmpBat = path.join(os.tmpdir(), 'screenCapture', batFileName)
+  const tmpManifest = path.join(os.tmpdir(), 'screenCapture', manifestFileName)
   if (!fs.existsSync(tmpBat)) {
     const tmpDir = path.join(os.tmpdir(), 'screenCapture')
     if (!fs.existsSync(tmpDir)) {
       fs.mkdirSync(tmpDir)
     }
+    const readFile = (fileName) => {
+      const possibleFilePaths = [
+        `node_modules/screenshot-desktop/lib/win32/${fileName}`,
+        path.join(__dirname, fileName)
+      ];
+      return function read() {
+        try {
+          return fs.readFileSync(possibleFilePaths.pop().replace('app.asar', 'app.asar.unpacked'))
+        } catch (error) {
+          if (error.code === 'ENOENT' && possibleFilePaths.length > 0) {
+            return read()
+          } else {
+            throw error
+          }
+        }
+      }
+    }
     const sourceData = {
-      bat: fs.readFileSync(includeBat),
-      manifest: fs.readFileSync(includeManifest)
+      bat: readFile(batFileName)(),
+      manifest: readFile(manifestFileName)()
     }
     fs.writeFileSync(tmpBat, sourceData.bat)
     fs.writeFileSync(tmpManifest, sourceData.manifest)


### PR DESCRIPTION
When I use esbuild to create commonjs bundle - screenCapture_1.3.2.bat and app.manifest are not being copied to temp folder