### PR TITLE
fix: Long delay in listDisplays() xrandr call #302

### DIFF
--- a/lib/linux/index.js
+++ b/lib/linux/index.js
@@ -115,7 +115,7 @@ function parseDisplaysOutput (out) {
 
 function listDisplays () {
   return new Promise((resolve, reject) => {
-    exec('xrandr', (err, stdout) => {
+    exec('xrandr --current', (err, stdout) => {
       if (err) {
         return reject(err)
       }


### PR DESCRIPTION
Fixes #302 

Call xrandr with the `--current` switch, which skips hardware polling and uses the current screen configuration directly.  This eliminates a long (~1.6 second) delay that locks up the system.

Benchmark of `listDisplays()` before:
```
real    0m1.672s
user    0m0.034s
sys     0m0.013s
```

After fix:
```
real    0m0.085s
user    0m0.054s
sys     0m0.033s
```